### PR TITLE
Add "How to install/register plugin" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # mackerel-plugin-registry
+
+Official mackerel and check plugin registry.  Registered plugins can be installed by `mkr plugin install <plugin_name>`.
+
+## How to install a plugin
+
+You can find available plugins in the `plugins/` directory.
+
+For example, if you want to the plugin defined in `mackerel-plugin-sample.json`, exec following command in your terminal.
+
+```
+$ mkr plugin install mackerel-plugin-sample
+```
+
+## How to register a plugin
+
+1. Put your plugin on Github, and make your repository satisfy the specification of `mkr plugin install`.
+2. Create `<plugin_name>.json` in the `plugins/` directory
+3. Write the path of your plugin's repository to `source` field.
+    - For example, if your plugin repository is https://github.com/mackerelio/mackerel-plugin-sample, write `mackerelio/mackerel-plugin-sample`.
+4. Write the description of your plugin to `description` field.
+5. Send pull request.
+
+If you want an example, please see https://github.com/mackerelio/plugin-registry/blob/master/plugins/mackerel-plugin-sample.json .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mackerel-plugin-registry
 
-Official mackerel and check plugin registry.  Registered plugins can be installed by `mkr plugin install <plugin_name>`.
+The registry of mackerel and check plugins.  Registered plugins can be installed by `mkr plugin install <plugin_name>`.
 
 ## How to install a plugin
 


### PR DESCRIPTION
- Add "How to install" and "How to register" sections to README.md
- After the documents are translated in English, I will add reference URL for detail