### PR TITLE
add check-mackerel-metric

### DIFF
--- a/plugins/check-mackerel-metric.json
+++ b/plugins/check-mackerel-metric.json
@@ -1,0 +1,4 @@
+{
+    "source": "mackerelio-labs/check-mackerel-metric",
+    "description": "Check Mackerel host metrics (or service metrics) are still being posted"
+}


### PR DESCRIPTION
check-mackerel-metric now becomes mackerelio-labs product release. ( https://github.com/mackerelio-labs/check-mackerel-metric )
I'd like to add this check-mackerel-metric repository to mkr registry for user's convenience.
